### PR TITLE
Add Privacy Policy page, footer link, and Vercel rewrites for /privacy

### DIFF
--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -36,10 +36,22 @@
       p { margin: 0 0 12px; color: var(--muted); }
       .meta { margin-bottom: 20px; color: var(--text); }
       a { color: var(--accent); }
+      .back-link {
+        display: inline-flex;
+        align-items: center;
+        margin-bottom: 16px;
+        font-size: 0.9rem;
+        text-decoration: none;
+        color: var(--muted);
+      }
+      .back-link:hover {
+        color: var(--accent);
+      }
     </style>
   </head>
   <body>
     <main>
+      <a class="back-link" href="/#home">← Back to Deal Flow Hub</a>
       <h1>Privacy Policy</h1>
       <p class="meta"><strong>Company:</strong> Deal Flow Hub</p>
       <p class="meta"><strong>Effective Date:</strong> February 27, 2026</p>

--- a/public/privacy/index.html
+++ b/public/privacy/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Privacy Policy | Deal Flow Hub</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0d0d14;
+        --surface: #16161f;
+        --border: #2a2a3a;
+        --text: #e8e8f0;
+        --muted: #a1a1bf;
+        --accent: #8b85ff;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        line-height: 1.65;
+      }
+      main {
+        max-width: 860px;
+        margin: 32px auto;
+        padding: 24px;
+        background: var(--surface);
+        border: 1px solid var(--border);
+        border-radius: 14px;
+      }
+      h1, h2 { line-height: 1.3; margin: 0 0 12px; }
+      h1 { font-size: 2rem; }
+      h2 { margin-top: 22px; font-size: 1.15rem; color: var(--accent); }
+      p { margin: 0 0 12px; color: var(--muted); }
+      .meta { margin-bottom: 20px; color: var(--text); }
+      a { color: var(--accent); }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Privacy Policy</h1>
+      <p class="meta"><strong>Company:</strong> Deal Flow Hub</p>
+      <p class="meta"><strong>Effective Date:</strong> February 27, 2026</p>
+
+      <h2>Introduction</h2>
+      <p>Deal Flow Hub values your privacy. This Privacy Policy explains what information we collect, how we use it, and your rights regarding your information when you use our services.</p>
+
+      <h2>Information We Collect</h2>
+      <p>We may collect information you provide directly (such as account and contact information), information collected automatically through your use of our website, and data from third-party services you choose to connect.</p>
+
+      <h2>How We Use Information</h2>
+      <p>We use information to operate and improve Deal Flow Hub, personalize user experiences, communicate updates, provide customer support, monitor platform performance, and comply with legal obligations.</p>
+
+      <h2>Cookies &amp; Analytics</h2>
+      <p>We may use cookies and similar technologies to remember preferences, understand usage patterns, and measure website performance. Analytics tools may collect device and browsing information.</p>
+
+      <h2>How We Share Information</h2>
+      <p>We may share information with service providers who help us operate the platform, when required by law, or in connection with business transactions. We do not sell personal information.</p>
+
+      <h2>Data Retention</h2>
+      <p>We retain information for as long as needed to provide our services, resolve disputes, enforce agreements, and satisfy legal requirements.</p>
+
+      <h2>Security</h2>
+      <p>We use reasonable administrative, technical, and organizational safeguards to protect information. No method of transmission or storage is completely secure.</p>
+
+      <h2>Your Choices</h2>
+      <p>You may update certain account information, manage cookie preferences through your browser settings, and contact us regarding access, correction, or deletion requests where applicable.</p>
+
+      <h2>Children’s Privacy</h2>
+      <p>Deal Flow Hub is not directed to children under 13, and we do not knowingly collect personal information from children under 13.</p>
+
+      <h2>Changes to This Policy</h2>
+      <p>We may update this Privacy Policy from time to time. Updates will be posted on this page with a revised effective date when appropriate.</p>
+
+      <h2>Contact Us</h2>
+      <p>If you have questions about this Privacy Policy, contact us at <a href="mailto:contact@dealflowhub.xyz">contact@dealflowhub.xyz</a>.</p>
+    </main>
+  </body>
+</html>

--- a/styles.js
+++ b/styles.js
@@ -2169,6 +2169,9 @@ function Footer(){
       an affiliate advertising program designed to provide a means for sites to earn
       advertising fees by advertising and linking to Amazon.com. As an Amazon Associate,
       we earn from qualifying purchases at no extra cost to you.
+      <div style={{marginTop:10}}>
+        <a href="/privacy" style={{color:"var(--p2)",textDecoration:"underline"}}>Privacy Policy</a>
+      </div>
     </footer>
   );
 }

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,17 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "rewrites": [
-    { "source": "/(.*)", "destination": "/index.html" }
+    {
+      "source": "/privacy",
+      "destination": "/privacy/index.html"
+    },
+    {
+      "source": "/privacy/",
+      "destination": "/privacy/index.html"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
   ]
 }


### PR DESCRIPTION
### Motivation

- Provide a dedicated Privacy Policy page so users can review data handling and compliance information. 
- Ensure the policy is reachable from the site footer and that the static hosting routes `/privacy` to the new document.

### Description

- Add `public/privacy/index.html` containing a styled Privacy Policy document with company, effective date, sections on data collection, usage, sharing, retention, security, and contact details. 
- Update the `Footer` component in `styles.js` to include a link to `/privacy` so the policy is discoverable from every page. 
- Update `vercel.json` rewrites to map both `/privacy` and `/privacy/` to `/privacy/index.html` while preserving the existing catch-all rewrite to `index.html`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a1fcc3b9c88326b963218a5986c32a)