### PR TITLE
Fix raffle AMOE contact and standardize prize to $10

### DIFF
--- a/styles.js
+++ b/styles.js
@@ -111,6 +111,7 @@ const tu = (d)=>{
 };
 
 const fmtDate = (s) => new Date(s).toLocaleDateString("en-US",{month:"short",day:"numeric",year:"numeric"});
+export const PRIZE_AMOUNT_USD = 10;
 
 // ── Seed data ────────────────────────────────────────────────
 const CATS = [
@@ -710,9 +711,10 @@ function VoteBar({deal, onVoted, compact=false}){
 function RaffleBanner(){
   const {nav}=useRouter();
   const [open,setOpen]=useState(false);
+  const prizeAmount = `$${PRIZE_AMOUNT_USD}`;
   return(
     <div style={{background:"linear-gradient(90deg,#4338ca,#7c3aed)",color:"#fff",padding:"12px 24px",textAlign:"center",fontSize:14}}>
-      <strong>🎁 Refer friends & family for a chance to win $20 cash.</strong> Winner picked every week.{" "}
+      <strong>🎁 Refer friends & family for a chance to win {prizeAmount} cash.</strong> Winner picked every week.{" "}
       <span
         style={{cursor:"pointer",textDecoration:"underline",color:"#fde68a",fontWeight:700}}
         onClick={()=>setOpen(o=>!o)}
@@ -725,7 +727,7 @@ function RaffleBanner(){
           <p><strong>No purchase necessary</strong> to enter or win.</p>
           <p><strong>How to enter:</strong> Share your unique referral link from the Raffle page. When someone signs up using your link, confirms their email, and logs in, you both get +1 raffle entry for the current week.</p>
           <p><strong>Winner selection:</strong> One winner is randomly selected every Sunday at 11:59 PM CT from all valid entries for that week.</p>
-          <p><strong>How winner is contacted:</strong> By email within 24 hours of the drawing. Winner must respond within 7 days to claim the $20 prize (via PayPal or Venmo).</p>
+          <p><strong>How winner is contacted:</strong> By email within 24 hours of the drawing. Winner must respond within 7 days to claim the {prizeAmount} prize (via PayPal or Venmo).</p>
           <p><strong>Void where prohibited by law.</strong></p>
           <p style={{fontSize:11,opacity:.8,marginTop:8}}>This is a general summary. Please review the <span style={{textDecoration:"underline",cursor:"pointer"}} onClick={()=>nav("raffle")}>Full Official Rules</span> for complete details. Deal Flow Hub reserves the right to modify or cancel the promotion at any time.</p>
         </div>
@@ -2234,6 +2236,8 @@ function RafflePage(){
       .catch(()=>toast?.("Could not copy — please copy the link manually.","err"));
   };
 
+  const prizeAmount = `$${PRIZE_AMOUNT_USD}`;
+
   return(
     <div className="page" style={{maxWidth:720}}>
 
@@ -2279,9 +2283,11 @@ function RafflePage(){
       {[
         ["Eligibility","Open to legal residents of the United States who are 18 years of age or older at the time of entry. Void where prohibited by law. Employees of Deal Flow Hub and their immediate family members are not eligible."],
         ["Sweepstakes Period","Each weekly drawing period runs from Monday 12:00 AM Central Time (CT) through Sunday 11:59 PM CT. Entries do not carry over between weekly periods."],
-        ["How to Enter Without Purchase","To enter without referring anyone, send your full name and email to raffle@dealflowhub.com with the subject line 'Weekly Raffle Entry.' Limit one (1) free entry per person per weekly period."],
+        ["How to Enter Without Purchase",<>
+          To enter without referring anyone, send your full name and email to <a href="mailto:raffle@dealflowhub.xyz" style={{color:"var(--p)",textDecoration:"underline"}}>raffle@dealflowhub.xyz</a> with the subject line 'Weekly Raffle Entry.' Limit one (1) free entry per person per weekly period.
+        </>],
         ["Referral Entries","Share your unique referral link from this page. When a new user signs up via your link, confirms their email, and logs in for the first time, both you and the new user each receive one (1) raffle entry for the current weekly period. The bonus is applied automatically on the referee's first login after email confirmation. Self-referrals are not permitted. Each person may only be referred once. Fraudulent entries will be disqualified."],
-        ["Prize","One (1) winner per weekly period receives $20 USD via PayPal or Venmo. No cash equivalent substitution. Prize is non-transferable. Winner is responsible for all applicable taxes."],
+        ["Prize",`One (1) winner per weekly period receives ${prizeAmount} USD via PayPal or Venmo. No cash equivalent substitution. Prize is non-transferable. Winner is responsible for all applicable taxes.`],
         ["Winner Selection","One winner is randomly selected from all valid entries received during the weekly period. Odds of winning depend on total entries received."],
         ["Winner Notification","Winners are contacted by email within 24 hours of selection and must respond within 7 calendar days to claim the prize. Unclaimed prizes will result in a new drawing."],
         ["Privacy","Information collected for this sweepstakes will be used solely to administer the drawing and will not be sold to third parties except as required by law."],


### PR DESCRIPTION
### Motivation
- Ensure the raffle "How to Enter Without Purchase" / AMOE text uses the exact contact address and mailto required for compliance and support routing. 
- Make the displayed prize amount consistent across UI by centralizing the value into a single constant to avoid future mismatches. 

### Description
- Replaced the AMOE/no-purchase contact with the exact email and link `raffle@dealflowhub.xyz` and `mailto:raffle@dealflowhub.xyz` in the raffle rules UI (file: `styles.js`).
- Added a shared constant `export const PRIZE_AMOUNT_USD = 10;` and used it to render the prize as `$10` in the Home raffle banner and the Raffle/Refer rules UI (file: `styles.js`).
- Replaced hard-coded `$20` prize strings in the UI with uses of the `PRIZE_AMOUNT_USD` constant so the displayed value is `$10` everywhere required. 
- Verified that `requests@dealflowhub.xyz` and `contact@dealflowhub.xyz` are not used in the raffle AMOE section (the `contact@dealflowhub.xyz` address remains only in the Privacy page). 

### Testing
- Ran repository searches (`rg`) to validate email occurrences and prize text replacements, which confirmed `raffle@dealflowhub.xyz` is present in the AMOE and the other addresses are not used there. 
- Built the application with `npm run build`, which completed successfully. 
- Launched a local dev server and captured a screenshot of the updated raffle page to validate the UI changes. 
- Attempted `npm test` but no test script is defined in `package.json`, so automated test execution did not run (reported as not applicable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a215b08b2c8326bc9487975596934f)