### PR TITLE
Deal cards: hide public counts, add relative “Added X ago”, clamp description, and support stackable deals

### DIFF
--- a/supabase/migrations/009_add_stackable_fields.sql
+++ b/supabase/migrations/009_add_stackable_fields.sql
@@ -1,0 +1,12 @@
+-- Add stackable metadata fields for deal-card rendering.
+ALTER TABLE deals
+  ADD COLUMN IF NOT EXISTS is_stackable BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE deals
+  ADD COLUMN IF NOT EXISTS stack_options TEXT[] NOT NULL DEFAULT '{}'::text[];
+
+-- Backfill values from existing deal_type semantics.
+UPDATE deals
+SET is_stackable = true
+WHERE deal_type IN ('STACKABLE','BOTH')
+  AND is_stackable = false;


### PR DESCRIPTION
### Motivation
- Remove public-facing click/view/saved counts from deal cards and detail view while keeping internal click tracking for analytics. 
- Surface when a deal was added using `created_at` in a compact, user-friendly relative format that updates automatically. 
- Improve card UX by showing a short, clamped description under the title and adding explicit stackable metadata so stackable offers can be highlighted without breaking the grid. 

### Description
- Removed public click/saved counts from the card and detail metadata while leaving internal tracking RPC calls (`increment_deal_clicks`) intact. 
- Added a `timeSince` helper to render relative labels like `Added 3 hours ago` / `Added 2 days ago` and wired a minute `setInterval` tick so timestamps auto-refresh. 
- Rendered the deal short description under the title with a 2-line clamp, ellipsis, and a `minHeight` to keep card heights consistent. 
- Added `isStackable` and `stackOptions` to the DB↔UI mapping and admin form, plus UI elements: a `Stackable` badge on cards, optional stack options preview on cards, and a full stack-options list/section on the deal detail. 
- Added a Supabase migration `supabase/migrations/009_add_stackable_fields.sql` to create/backfill `is_stackable` and `stack_options` fields. 

### Testing
- Built the app with `npm run build` and the production build completed successfully. 
- Started the dev server with `npm run dev` and rendered a visual snapshot using Playwright to validate the updated card UI (screenshot artifact captured). 
- Confirmed the UI no longer shows public counts, the `Added X ago` text renders from `created_at` and updates, description is clamped to 2 lines, and stackable badge/options display when `is_stackable`/`stack_options` are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a21991a1488326872e22e5251cec25)