### PR TITLE
Add filters, full-text search, and sorting to Deals page

### DIFF
--- a/styles.js
+++ b/styles.js
@@ -930,8 +930,12 @@ function DealsPage(){
       const needle=q.toLowerCase();
       list=list.filter(d=>`${d.title||""} ${(d.description||"")}`.toLowerCase().includes(needle));
     }
+    const getCreatedAtTime=(value)=>{
+      const t=new Date(value).getTime();
+      return Number.isNaN(t)?0:t;
+    };
     list=[...list].sort((a,b)=>{
-      if(sortBy==="NEWEST") return new Date(b.createdAt)-new Date(a.createdAt);
+      if(sortBy==="NEWEST") return getCreatedAtTime(b.createdAt)-getCreatedAtTime(a.createdAt);
       if(sortBy==="HIGHEST_DISCOUNT") return (b.percentOff??-1)-(a.percentOff??-1);
       if(sortBy==="LOWEST_PRICE") return (a.currentPrice??Infinity)-(b.currentPrice??Infinity);
       if(sortBy==="PRICE_HIGH_TO_LOW") return (b.currentPrice??-1)-(a.currentPrice??-1);

--- a/styles.js
+++ b/styles.js
@@ -865,7 +865,10 @@ function DealsPage(){
   const isNewThisWeek=(createdAt)=>{
     const now=new Date();
     const created=new Date(createdAt);
-    return now-created<=7*24*60*60*1000;
+    const createdTime=created.getTime();
+    if(Number.isNaN(createdTime)) return false;
+    const diff=now-created;
+    return diff>=0&&diff<=7*24*60*60*1000;
   };
 
   const getPopularityScore=(deal)=>(deal.saved||0)*5+(deal.voteUp||0)*3-(deal.voteDown||0)*2+(deal.clicks||0);


### PR DESCRIPTION
### Motivation
- Expose the requested filtering controls (Deal Type, Price, Discount, Category, Freshness, Stackable-only) so users can narrow deals by common criteria.
- Provide full-text search across a deal's `title` and `description` and update placeholder text to better reflect search scope.
- Add sorting options (including an internal "Most Popular" ranking) so users can order results by engagement and price.

### Description
- Added new state variables `price`, `discount`, `freshness`, `dealType`, and `sortBy` and wired them into `DealsPage` filter/sort logic so the UI controls drive the list computation. (`styles.js`)
- Implemented predicate helpers `dealTypeMatches`, `priceMatches`, `discountMatches`, and `freshnessMatches` and applied them in the `useMemo` that builds `deals`, and changed the stackable control to filter on `d.isStackable === true`. (`styles.js`)
- Updated the Sidebar to include radio groups for `Deal Type` (All / Instant Deals / Promo Code Required), `Price` (All / Under $20 / Under $50 / $50–$100 / $100+), `Discount` (25%+, 50%+, 70%+, 80%+), and `Freshness` (All / New Today / New This Week), while keeping the existing `Category` structure and explicitly not adding any store/retailer filter. (`styles.js`)
- Implemented full-text search across `title + description` (changed placeholder to `"Search deals, brands, products…"`) and added a `select` for sorting with options `Most Popular`, `Newest`, `Highest Discount`, `Lowest Price`, and `Price: High to Low`; `Most Popular` uses an internal weighted engagement score and does not surface click counts. (`styles.js`)

### Testing
- Built the project with `npm run build` and the build completed successfully. 
- Started the dev server with `npm run dev` and performed an automated visual check (screenshot) to verify the new filters, search placeholder, and sort control render correctly; the check completed successfully. 
- No unit test suite was present/modified, and no store/retailer filter was added during the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a21e0a61d88326b317829b94097d01)