### PR TITLE
Remove On Sale and Promo Codes CTAs from Home hero

### DIFF
--- a/styles.js
+++ b/styles.js
@@ -791,8 +791,6 @@ function HomePage(){
         </p>
         <div style={{display:"flex",gap:12,justifyContent:"center",flexWrap:"wrap"}}>
           <button className="btn btn-p" onClick={()=>nav("deals")}>Browse All Deals</button>
-          <button className="btn btn-o" onClick={()=>nav("deals",{dt:"SALE"})}>On Sale</button>
-          <button className="btn btn-o" onClick={()=>nav("deals",{dt:"PROMO"})}>Promo Codes</button>
         </div>
       </div>
 


### PR DESCRIPTION
### Motivation
- Remove the secondary homepage hero buttons labeled "On Sale" and "Promo Codes" so the hero/top area shows only the primary CTA while leaving routes, data, categories, and filters untouched.

### Description
- Removed the two CTA buttons from `HomePage` in `styles.js` so the hero now only renders the `Browse All Deals` button; left deal-type label constants (e.g. `DT_LABEL`) and other logic unchanged.

### Testing
- Ran `rg -n "On Sale|Promo Codes|Browse All Deals|Deal Flow Hub|#home|Home" .` and inspected `styles.js` to confirm the two buttons are no longer present and `Browse All Deals` remains (success).
- Verified the source diff shows only the two button lines removed from `styles.js` (success).
- Attempted `npm run build` after `npm install`, but build could not complete in this environment because the `vite` binary was unavailable (build not completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a2503ec38c8326a19fcbaa6229ed1a)