### PR TITLE
Add persistent 18+ verification gate for Adult Products category

### DIFF
--- a/styles.js
+++ b/styles.js
@@ -142,6 +142,9 @@ const CATS = [
   {id:"adult-products",           label:"Adult Products",           emoji:"🔞", adult:true },
 ];
 
+const ADULT_OK_STORAGE_KEY = "dfh_adult_ok";
+const isAdultCategory = (catId)=>CATS.some(c=>c.id===catId&&c.adult);
+
 // ── DB field mapping ──────────────────────────────────────────
 const fromDb = (d) => ({
   id:               d.id,
@@ -311,15 +314,27 @@ const AgeCtx = createContext(null);
 const useAge = () => useContext(AgeCtx);
 
 function AgeProvider({children}){
-  const [ok,setOk]=useState(false);
+  const [ok,setOk]=useState(()=>localStorage.getItem(ADULT_OK_STORAGE_KEY)==="true");
   const [show,setShow]=useState(false);
-  const [cb,setCb]=useState(null);
+  const [handlers,setHandlers]=useState({onConfirm:null,onDeny:null});
 
-  const ageReq=(callback)=>{ setCb(()=>callback); setShow(true); };
+  const ageReq=(onConfirm,onDeny=null)=>{
+    setHandlers({onConfirm,onDeny});
+    setShow(true);
+  };
 
-  // Bug 7 fixed: call cb() before setCb(null)
-  const confirm=()=>{ setOk(true); setShow(false); if(cb) cb(); setCb(null); };
-  const deny   =()=>{ setShow(false); setCb(null); };
+  const confirm=()=>{
+    localStorage.setItem(ADULT_OK_STORAGE_KEY,"true");
+    setOk(true);
+    setShow(false);
+    handlers.onConfirm?.();
+    setHandlers({onConfirm:null,onDeny:null});
+  };
+  const deny=()=>{
+    setShow(false);
+    handlers.onDeny?.();
+    setHandlers({onConfirm:null,onDeny:null});
+  };
 
   return(
     <AgeCtx.Provider value={{ageOk:ok,ageReq}}>
@@ -328,13 +343,13 @@ function AgeProvider({children}){
         <div className="modal-bg">
           <div className="modal" style={{textAlign:"center"}}>
             <I n="shield" s={40} c="var(--warn)" style={{marginBottom:16}}/>
-            <h2 style={{marginBottom:8}}>Age Verification</h2>
+            <h2 style={{marginBottom:8}}>Adults only (18+). Are you 18 or older?</h2>
             <p style={{color:"var(--muted)",marginBottom:24}}>
-              This category contains adult content. You must be 18+ to continue.
+              This category contains adult content.
             </p>
             <div style={{display:"flex",gap:12,justifyContent:"center"}}>
-              <button className="btn btn-p" onClick={confirm}>I am 18+</button>
-              <button className="btn btn-d" onClick={deny}>Go Back</button>
+              <button className="btn btn-p" onClick={confirm}>Yes, I’m 18+</button>
+              <button className="btn btn-d" onClick={deny}>No</button>
             </div>
           </div>
         </div>
@@ -768,14 +783,18 @@ function RaffleBanner(){
 // ── HomePage ──────────────────────────────────────────────────
 function HomePage(){
   const {nav}=useRouter();
+  const {ageOk}=useAge();
   const [featured,setFeatured]=useState([]);
 
   useEffect(()=>{
     supabase.from('deals').select('*')
       .eq('featured',true).eq('status','ACTIVE')
       .order('created_at',{ascending:false}).limit(4)
-      .then(({data})=>setFeatured((data||[]).map(fromDb)));
-  },[]);
+      .then(({data})=>{
+        const list=(data||[]).map(fromDb);
+        setFeatured(ageOk?list:list.filter(d=>!isAdultCategory(d.cat)));
+      });
+  },[ageOk]);
 
   return(
     <div>
@@ -842,6 +861,7 @@ function DealsPage(){
   const [sortBy,setSortBy]=useState("POPULAR");
   const [sideOpen,setSideOpen]=useState(false);
   const [allDeals,setAllDeals]=useState([]);
+  const lastNonAdultCatRef=useRef("");
 
   useEffect(()=>{
     supabase.from('deals').select('*').order('created_at',{ascending:false})
@@ -850,11 +870,24 @@ function DealsPage(){
 
   // Bug 5 fixed: sync filter state when params change (e.g. navigating from Home → different filter)
   useEffect(()=>{
+    const nextCat=params.cat||"";
     setDealType(params.dt||"ALL");
-    setCat(params.cat||"");
+    if(nextCat&&isAdultCategory(nextCat)&&!ageOk){
+      ageReq(
+        ()=>setCat(nextCat),
+        ()=>setCat(lastNonAdultCatRef.current||"")
+      );
+      setCat(lastNonAdultCatRef.current||"");
+    } else {
+      setCat(nextCat);
+    }
     setStack(!!params.stack);
     setQ(params.q||"");
-  },[params.dt,params.cat,params.stack,params.q]);
+  },[params.dt,params.cat,params.stack,params.q,ageOk]);
+
+  useEffect(()=>{
+    if(cat&&!isAdultCategory(cat)) lastNonAdultCatRef.current=cat;
+  },[cat]);
 
   const isNewToday=(createdAt)=>{
     const now=new Date();
@@ -912,7 +945,8 @@ function DealsPage(){
   const pickCat=(id)=>{
     const found=CATS.find(c=>c.id===id);
     if(found?.adult&&!ageOk){
-      ageReq(()=>setCat(id));
+      const fallback=(cat&&!isAdultCategory(cat))?cat:lastNonAdultCatRef.current||"";
+      ageReq(()=>setCat(id),()=>setCat(fallback));
     } else {
       setCat(id);
     }
@@ -920,6 +954,7 @@ function DealsPage(){
 
   const deals=useMemo(()=>{
     let list=allDeals.filter(d=>d.status==="ACTIVE");
+    if(!ageOk) list=list.filter(d=>!isAdultCategory(d.cat));
     list=list.filter(dealTypeMatches);
     if(cat)  list=list.filter(d=>d.cat===cat);
     if(stack)list=list.filter(d=>d.isStackable===true);


### PR DESCRIPTION
### Motivation
- Prevent unverified users from viewing adult deal content while keeping the `Adult Products` category visible in lists and navigation.
- Provide a clear, persistent consent flow so users are not re-prompted during the same browser session once they confirm they are 18+.

### Description
- Added `ADULT_OK_STORAGE_KEY = "dfh_adult_ok"` and a shared `isAdultCategory` helper to centralize adult-category checks in `styles.js`.
- Implemented an age gate (`AgeProvider`) modal with copy: `Adults only (18+). Are you 18 or older?` and buttons `Yes, I’m 18+` and `No`, storing consent in `localStorage` (`dfh_adult_ok=true`) on confirm.
- Intercepted category navigation and filter selection for `adult-products` to prompt the age gate before applying the adult category, and restore the last non-adult category (or All) when the user selects `No`.
- Ensured adult deals are excluded from homepage featured lists and from deal results unless `ageOk` is true, keeping adult category tiles visible but hiding thumbnails/cards until verification.

### Testing
- Ran `npm run build` and the build completed successfully.
- Started the dev server with `npm run dev` and Vite reported ready (local and network URLs available).
- Executed automated Playwright-based checks to open the homepage and capture a screenshot; the environment produced a page snapshot but clicking the adult tile in headless automation timed out in one attempt, indicating the modal rendering and navigation flow should be manually verified in a browser if needed.

Files changed:
- `styles.js` (age gate, localStorage persistence, adult-category filtering and navigation handling)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a25085346c8326a656be03ed98566d)