### PR TITLE
Add Contact Us details to global footer

### DIFF
--- a/styles.js
+++ b/styles.js
@@ -2349,6 +2349,22 @@ function Footer(){
       lineHeight:1.7,
       textAlign:"center"
     }}>
+      <div style={{marginBottom:14}}>
+        <h3 style={{fontSize:16,fontWeight:700,color:"var(--txt)",marginBottom:6}}>Contact Us</h3>
+        <p>
+          General questions:{" "}
+          <a href="mailto:contact@dealflowhub.xyz" style={{color:"var(--p2)",textDecoration:"underline"}}>
+            contact@dealflowhub.xyz
+          </a>
+        </p>
+        <p>
+          Request a deal:{" "}
+          <a href="mailto:requests@dealflowhub.xyz" style={{color:"var(--p2)",textDecoration:"underline"}}>
+            requests@dealflowhub.xyz
+          </a>
+        </p>
+      </div>
+
       <strong style={{color:"var(--txt)"}}>Amazon Affiliate Disclosure:</strong>{" "}
       Deal Flow Hub is a participant in the Amazon Services LLC Associates Program,
       an affiliate advertising program designed to provide a means for sites to earn


### PR DESCRIPTION
### Motivation
- Provide site-wide contact information and an explicit pathway for deal submissions to meet the requested separation of email responsibilities.
- Increase user trust and clarity by surfacing easy-to-use `mailto:` links for general questions and deal requests in the global footer.

### Description
- Inserted a "Contact Us" block into the `Footer` component in `styles.js` with a heading and two mailto links: `contact@dealflowhub.xyz` (general questions) and `requests@dealflowhub.xyz` (request a deal). 
- Preserved the existing footer styling and the Amazon affiliate disclosure, and limited the change to adding the contact block above the disclosure.

### Testing
- Ran `npm run build` which completed successfully.
- Ran an automated Playwright script to load the home page and capture a full-page screenshot showing the updated footer, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a2520d02288326bdea904e69bcf7ab)