### PR TITLE
Remove 'Stackable' option from Add Deal form and Deals filters

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -76,7 +76,7 @@ export function parseDealText(raw, cats = []) {
     const isNone = /^(\(none\)|none|n\/a|-)$/i.test(value);
     switch (key) {
       case 'title': out.title = value; break;
-      case 'dealtype': { const dt = value.toUpperCase(); if (['SALE','PROMO','BOTH','STACKABLE'].includes(dt)) out.dealType = dt; break; }
+      case 'dealtype': { const dt = value.toUpperCase(); if (['SALE','PROMO','BOTH'].includes(dt)) out.dealType = dt; break; }
       case 'description': out.description = value; break;
       case 'productimageurl': case 'imageurl': case 'image': out.imageUrl = value; break;
       case 'producturl': case 'link': case 'url': out.link = value; break;


### PR DESCRIPTION
### Motivation
- Remove the legacy "Stackable" UI and filtering behavior so deals are no longer treated specially as stackable in the Add/Edit form or on the Deals page filter sidebar.

### Description
- Deal form: removed the `STACKABLE` deal-type option, removed the `Stackable` checkbox and `Stack Options` input, normalized incoming `initial.dealType === "STACKABLE"` to `SALE`, and removed stackable-required validation so stack instructions are no longer required.
- Deal save: ensure saves always submit `isStackable: false` and `stackOptions: []` by normalizing the payload in the form `onSave` call for backend compatibility.
- Deals page: removed `stack` filter state and `params.stack` syncing, removed the sidebar "Stackable Only" checkbox UI, removed the `if(stack) list = list.filter(...)` filtering line, and removed `stack` from the `useMemo` dependency list.
- Logic/parser: updated `dealTypeMatches` so `INSTANT` includes only `SALE` (no `STACKABLE`), and updated the text parser so parsed `dealtype` no longer accepts `STACKABLE`.

### Testing
- Ran `npm run build` which produced a successful production build (Vite build completed).
- Started the dev server (`npm run dev`) successfully but automated browser screenshot via Playwright failed in this environment due to a Chromium crash (non-deterministic environment issue), so no UI screenshot was captured.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a48ed7142083268a4826cbf6d65801)