### PR TITLE
Add Telegram webhook for batch listing creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -787,3 +787,7 @@ This means one or more migrations have not been applied to your Supabase project
 | Configure Auth redirect URLs | ✅ Yes | See `docs/supabase-auth.md` |
 | New users getting a profile row | 🤖 Automatic | The trigger in `000_profiles_table.sql` handles this |
 | Save & Earn seed data | 🤖 Automatic | Inserted by `005_methods_table.sql` if the table is empty |
+
+## Telegram batch bot
+
+See `docs/telegram-batch-listings.md` for setup and usage of batch listing import via Telegram webhook.

--- a/api/telegram/webhook.js
+++ b/api/telegram/webhook.js
@@ -1,0 +1,3 @@
+import { createTelegramWebhookHandler } from '../../src/telegramWebhook.js';
+
+export default createTelegramWebhookHandler();

--- a/docs/telegram-batch-listings.md
+++ b/docs/telegram-batch-listings.md
@@ -1,0 +1,73 @@
+# Telegram Batch Listings Setup (Simple)
+
+This guide lets your Telegram bot post **multiple listings in one message** into your DealflowHub site.
+
+## 1) Add environment variables in Vercel
+
+In your Vercel project → **Settings → Environment Variables**, add:
+
+- `TELEGRAM_BOT_TOKEN` = token from BotFather
+- `TELEGRAM_WEBHOOK_SECRET` = any long random string (example: generated password)
+- `SUPABASE_URL` = your Supabase project URL
+- `SUPABASE_SERVICE_ROLE_KEY` = your Supabase service role key
+
+> Keep `SUPABASE_SERVICE_ROLE_KEY` private. Never share it in chat or frontend code.
+
+## 2) Deploy to Vercel
+
+Push this branch to GitHub and deploy.
+
+## 3) Set Telegram webhook
+
+After deploy, set webhook with your production URL:
+
+```bash
+curl -X POST "https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/setWebhook" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://<your-vercel-domain>/api/telegram/webhook?secret=<TELEGRAM_WEBHOOK_SECRET>",
+    "secret_token": "<TELEGRAM_WEBHOOK_SECRET>"
+  }'
+```
+
+## 4) Send a batch message to your bot
+
+Use `===` between listings:
+
+```text
+Title: Listing One
+Deal Type: SALE
+Description: First listing
+Product Image URL: https://example.com/image1.jpg
+Product URL: https://example.com/deal1
+Featured: false
+Status: ACTIVE
+
+===
+
+Title: Listing Two
+Deal Type: PROMO
+Description: Second listing
+Product Image URL: https://example.com/image2.jpg
+Product URL: https://example.com/deal2
+Promo Code: SAVE20
+Featured: false
+Status: ACTIVE
+```
+
+## 5) Expected result
+
+The bot replies with:
+
+- total processed
+- succeeded count
+- failed count
+- per-listing failure reasons
+
+## Notes
+
+- The parser is tolerant of minor formatting differences in field labels.
+- `Title` is required.
+- For `PROMO` or `BOTH` listings, `Promo Code` is required.
+- For stackable listings, stack instructions are required.
+- `Product Image URL` is saved to `image_url`.

--- a/docs/telegram-batch-listings.md
+++ b/docs/telegram-batch-listings.md
@@ -25,7 +25,7 @@ After deploy, set webhook with your production URL:
 curl -X POST "https://api.telegram.org/bot<TELEGRAM_BOT_TOKEN>/setWebhook" \
   -H "Content-Type: application/json" \
   -d '{
-    "url": "https://<your-vercel-domain>/api/telegram/webhook?secret=<TELEGRAM_WEBHOOK_SECRET>",
+    "url": "https://<your-vercel-domain>/api/telegram/webhook",
     "secret_token": "<TELEGRAM_WEBHOOK_SECRET>"
   }'
 ```

--- a/src/listingCreation.js
+++ b/src/listingCreation.js
@@ -1,20 +1,6 @@
-export const CATEGORIES = [
-  { id: 'electronics', label: 'Electronics' },
-  { id: 'home-and-kitchen', label: 'Home & Kitchen' },
-  { id: 'clothing', label: 'Clothing' },
-  { id: 'beauty-and-personal-care', label: 'Beauty & Personal Care' },
-  { id: 'health-and-household', label: 'Health & Wellness' },
-  { id: 'tools-and-home-improvement', label: 'Tools & Home Improvement' },
-  { id: 'baby', label: 'Baby & Kids' },
-  { id: 'toys-and-games', label: 'Toys & Games' },
-  { id: 'sports-and-outdoors', label: 'Sports & Outdoors' },
-  { id: 'automotive', label: 'Automotive' },
-  { id: 'pet-supplies', label: 'Pet Supplies' },
-  { id: 'arts-and-crafts', label: 'Arts, Crafts & DIY' },
-  { id: 'other', label: 'Other' },
-  { id: 'adult-products', label: 'Adult Products' },
-];
+import { CATS } from './styles';
 
+export const CATEGORIES = CATS.map(({ id, label }) => ({ id, label }));
 export function buildDealFromParsed(parsed = {}) {
   const dealType = ['SALE', 'PROMO', 'BOTH', 'STACKABLE'].includes(parsed.dealType)
     ? parsed.dealType

--- a/src/listingCreation.js
+++ b/src/listingCreation.js
@@ -1,0 +1,87 @@
+export const CATEGORIES = [
+  { id: 'electronics', label: 'Electronics' },
+  { id: 'home-and-kitchen', label: 'Home & Kitchen' },
+  { id: 'clothing', label: 'Clothing' },
+  { id: 'beauty-and-personal-care', label: 'Beauty & Personal Care' },
+  { id: 'health-and-household', label: 'Health & Wellness' },
+  { id: 'tools-and-home-improvement', label: 'Tools & Home Improvement' },
+  { id: 'baby', label: 'Baby & Kids' },
+  { id: 'toys-and-games', label: 'Toys & Games' },
+  { id: 'sports-and-outdoors', label: 'Sports & Outdoors' },
+  { id: 'automotive', label: 'Automotive' },
+  { id: 'pet-supplies', label: 'Pet Supplies' },
+  { id: 'arts-and-crafts', label: 'Arts, Crafts & DIY' },
+  { id: 'other', label: 'Other' },
+  { id: 'adult-products', label: 'Adult Products' },
+];
+
+export function buildDealFromParsed(parsed = {}) {
+  const dealType = ['SALE', 'PROMO', 'BOTH', 'STACKABLE'].includes(parsed.dealType)
+    ? parsed.dealType
+    : 'SALE';
+
+  const status = ['ACTIVE', 'INACTIVE'].includes(parsed.status)
+    ? parsed.status
+    : 'ACTIVE';
+
+  return {
+    title: (parsed.title || '').trim(),
+    description: (parsed.description || '').trim(),
+    link: (parsed.link || '').trim(),
+    dealType,
+    code: (parsed.code || '').trim(),
+    cat: parsed.cat || 'other',
+    expires: parsed.expires || null,
+    featured: !!parsed.featured,
+    status,
+    imageUrl: (parsed.imageUrl || '').trim(),
+    stackInstructions: (parsed.stackInstructions || '').trim(),
+    isStackable: dealType === 'STACKABLE' || dealType === 'BOTH',
+    stackOptions: Array.isArray(parsed.stackOptions) ? parsed.stackOptions : [],
+    currentPrice: parsed.currentPrice ?? null,
+    originalPrice: parsed.originalPrice ?? null,
+    percentOff: parsed.percentOff ?? null,
+    asin: (parsed.asin || '').trim(),
+  };
+}
+
+export function validateDealForCreate(deal = {}) {
+  const errors = [];
+  if (!deal.title) errors.push('Title is required.');
+
+  if ((deal.dealType === 'PROMO' || deal.dealType === 'BOTH') && !deal.code) {
+    errors.push('Promo code is required for PROMO and BOTH deal types.');
+  }
+
+  if ((deal.isStackable || deal.dealType === 'STACKABLE') && !deal.stackInstructions) {
+    errors.push('Stack instructions are required for stackable deal types.');
+  }
+
+  return errors;
+}
+
+export function toDbDeal(deal = {}) {
+  return {
+    title: deal.title,
+    description: deal.description || '',
+    link: deal.link || '',
+    deal_type: deal.dealType,
+    code: deal.code || '',
+    category: deal.cat || 'other',
+    clicks: deal.clicks ?? 0,
+    saved: deal.saved ?? 0,
+    expires: deal.expires,
+    featured: deal.featured ?? false,
+    vote_up: deal.voteUp ?? 0,
+    vote_down: deal.voteDown ?? 0,
+    status: deal.status || 'ACTIVE',
+    image_url: deal.imageUrl || '',
+    stack_instructions: deal.stackInstructions || '',
+    is_stackable: deal.isStackable ?? ['STACKABLE', 'BOTH'].includes(deal.dealType),
+    stack_options: deal.stackOptions ?? [],
+    current_price: deal.currentPrice ?? null,
+    original_price: deal.originalPrice ?? null,
+    percent_off: deal.percentOff ?? null,
+    asin: deal.asin || null,
+  };
+}

--- a/src/telegramWebhook.js
+++ b/src/telegramWebhook.js
@@ -70,8 +70,7 @@ export function createTelegramWebhookHandler({
     }
 
     const headerSecret = req.headers['x-telegram-bot-api-secret-token'];
-    const querySecret = req.query?.secret;
-    if (headerSecret !== webhookSecret && querySecret !== webhookSecret) {
+    if (headerSecret !== webhookSecret) {
       res.status(401).json({ error: 'Unauthorized webhook secret.' });
       return;
     }

--- a/src/telegramWebhook.js
+++ b/src/telegramWebhook.js
@@ -31,15 +31,20 @@ function getChatId(update = {}) {
 async function sendTelegramMessage({ fetchImpl, botToken, chatId, text }) {
   if (!chatId || !text) return;
 
-  await fetchImpl(`https://api.telegram.org/bot${botToken}/sendMessage`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      chat_id: chatId,
-      text,
-      disable_web_page_preview: true,
-    }),
-  });
+  try {
+    await fetchImpl(`https://api.telegram.org/bot${botToken}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: chatId,
+        text,
+        disable_web_page_preview: true,
+      }),
+    });
+  } catch (error) {
+    // Log and swallow the error so the HTTP handler can still return 200 to Telegram
+    console.error('Failed to send Telegram message:', error);
+  }
 }
 
 export function createTelegramWebhookHandler({

--- a/src/telegramWebhook.js
+++ b/src/telegramWebhook.js
@@ -1,0 +1,154 @@
+import { createClient } from '@supabase/supabase-js';
+import { parseDealText } from './parser.js';
+import {
+  CATEGORIES,
+  buildDealFromParsed,
+  toDbDeal,
+  validateDealForCreate,
+} from './listingCreation.js';
+
+function splitListingBlocks(raw = '') {
+  return String(raw)
+    .split(/\n\s*===+\s*\n/g)
+    .map((block) => block.trim())
+    .filter(Boolean);
+}
+
+function ensureEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+function getMessageText(update = {}) {
+  return update?.message?.text || update?.edited_message?.text || '';
+}
+
+function getChatId(update = {}) {
+  return update?.message?.chat?.id || update?.edited_message?.chat?.id || null;
+}
+
+async function sendTelegramMessage({ fetchImpl, botToken, chatId, text }) {
+  if (!chatId || !text) return;
+
+  await fetchImpl(`https://api.telegram.org/bot${botToken}/sendMessage`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      chat_id: chatId,
+      text,
+      disable_web_page_preview: true,
+    }),
+  });
+}
+
+export function createTelegramWebhookHandler({
+  fetchImpl = fetch,
+  createSupabaseClient = (url, key) => createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  }),
+} = {}) {
+  return async function handler(req, res) {
+    if (req.method !== 'POST') {
+      res.status(405).json({ error: 'Method not allowed' });
+      return;
+    }
+
+    let botToken;
+    let webhookSecret;
+    let supabaseUrl;
+    let serviceRoleKey;
+
+    try {
+      botToken = ensureEnv('TELEGRAM_BOT_TOKEN');
+      webhookSecret = ensureEnv('TELEGRAM_WEBHOOK_SECRET');
+      supabaseUrl = ensureEnv('SUPABASE_URL');
+      serviceRoleKey = ensureEnv('SUPABASE_SERVICE_ROLE_KEY');
+    } catch (error) {
+      res.status(500).json({ error: error.message });
+      return;
+    }
+
+    const headerSecret = req.headers['x-telegram-bot-api-secret-token'];
+    const querySecret = req.query?.secret;
+    if (headerSecret !== webhookSecret && querySecret !== webhookSecret) {
+      res.status(401).json({ error: 'Unauthorized webhook secret.' });
+      return;
+    }
+
+    const text = getMessageText(req.body);
+    const chatId = getChatId(req.body);
+
+    if (!text || !chatId) {
+      res.status(200).json({ ok: true, ignored: true });
+      return;
+    }
+
+    const blocks = splitListingBlocks(text);
+    if (!blocks.length) {
+      await sendTelegramMessage({
+        fetchImpl,
+        botToken,
+        chatId,
+        text: 'No listing content found. Paste one or more listings separated with ===.',
+      });
+      res.status(200).json({ ok: true, processed: 0, created: 0, failed: 0 });
+      return;
+    }
+
+    const supabase = createSupabaseClient(supabaseUrl, serviceRoleKey);
+
+    const results = [];
+    for (let i = 0; i < blocks.length; i += 1) {
+      const parsed = parseDealText(blocks[i], CATEGORIES);
+      const deal = buildDealFromParsed(parsed);
+      const validationErrors = validateDealForCreate(deal);
+
+      if (validationErrors.length) {
+        results.push({ index: i + 1, title: deal.title || '(missing title)', ok: false, reason: validationErrors.join(' ') });
+        continue;
+      }
+
+      const payload = toDbDeal(deal);
+      const { error } = await supabase.from('deals').insert([payload]);
+
+      if (error) {
+        results.push({ index: i + 1, title: deal.title, ok: false, reason: error.message });
+      } else {
+        results.push({ index: i + 1, title: deal.title, ok: true });
+      }
+    }
+
+    const succeeded = results.filter((r) => r.ok).length;
+    const failed = results.length - succeeded;
+    const lines = [
+      `Batch processed: ${results.length}`,
+      `✅ Succeeded: ${succeeded}`,
+      `❌ Failed: ${failed}`,
+    ];
+
+    for (const result of results) {
+      if (result.ok) lines.push(`• #${result.index}: ✅ ${result.title}`);
+      else lines.push(`• #${result.index}: ❌ ${result.title} — ${result.reason}`);
+    }
+
+    await sendTelegramMessage({
+      fetchImpl,
+      botToken,
+      chatId,
+      text: lines.join('\n'),
+    });
+
+    res.status(200).json({
+      ok: true,
+      processed: results.length,
+      created: succeeded,
+      failed,
+      results,
+    });
+  };
+}
+
+export const _internal = {
+  splitListingBlocks,
+};

--- a/src/telegramWebhook.test.js
+++ b/src/telegramWebhook.test.js
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createTelegramWebhookHandler, _internal } from './telegramWebhook.js';
+
+function makeRes() {
+  return {
+    statusCode: 200,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+test('splitListingBlocks handles === separators and empty chunks', () => {
+  const input = 'Title: One\n===\n\n\nTitle: Two\n===\n  \nTitle: Three';
+  assert.deepEqual(_internal.splitListingBlocks(input), ['Title: One', 'Title: Two', 'Title: Three']);
+});
+
+test('telegram handler processes multiple listings and reports failures', async () => {
+  process.env.TELEGRAM_BOT_TOKEN = 'token';
+  process.env.TELEGRAM_WEBHOOK_SECRET = 'secret';
+  process.env.SUPABASE_URL = 'https://supabase.example';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+
+  const inserts = [];
+  const fetchCalls = [];
+
+  const handler = createTelegramWebhookHandler({
+    fetchImpl: async (url, options) => {
+      fetchCalls.push({ url, options });
+      return { ok: true, json: async () => ({ ok: true }) };
+    },
+    createSupabaseClient: () => ({
+      from() {
+        return {
+          insert(payload) {
+            inserts.push(payload[0]);
+            if (payload[0].title === 'Bad Promo') {
+              return { error: { message: 'db rejected row' } };
+            }
+            return { error: null };
+          },
+        };
+      },
+    }),
+  });
+
+  const req = {
+    method: 'POST',
+    headers: { 'x-telegram-bot-api-secret-token': 'secret' },
+    body: {
+      message: {
+        chat: { id: 12345 },
+        text: [
+          'Title: Good Sale',
+          'Deal Type: SALE',
+          'Product URL: https://example.com/sale',
+          '===',
+          'Title: Bad Promo',
+          'Deal Type: PROMO',
+          '===',
+          'Title: Missing Stack',
+          'Deal Type: STACKABLE',
+        ].join('\n'),
+      },
+    },
+    query: {},
+  };
+
+  const res = makeRes();
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.created, 1);
+  assert.equal(res.body.failed, 2);
+  assert.equal(inserts.length, 1);
+  assert.equal(fetchCalls.length, 1);
+  assert.match(fetchCalls[0].options.body, /Batch processed: 3/);
+});


### PR DESCRIPTION
### Motivation
- Add a secure Vercel webhook so a Telegram bot can accept one message containing multiple listings and publish them to the site. 
- Reuse the existing admin dashboard parsing and DB conventions so Telegram-created listings behave identically to listings created in the admin UI. 
- Keep the change additive and production-safe by using environment variables and the Supabase service role key for backend inserts. 

### Description
- Added `src/listingCreation.js` that normalizes parsed fields, validates required rules, and maps frontend fields to the `deals` DB shape used by the admin dashboard. 
- Implemented `src/telegramWebhook.js` which validates a webhook secret, splits incoming message text by `===`, parses each block with the existing `parseDealText` parser, validates each listing, inserts each listing independently via Supabase, and sends a Telegram summary reply. 
- Exposed a Vercel API route at `api/telegram/webhook.js` that delegates to the webhook handler, and added `docs/telegram-batch-listings.md` with simple setup and usage instructions. 
- Added `src/telegramWebhook.test.js` to verify separator handling and batch processing behavior, and updated `README.md` to reference the new docs. 

### Testing
- Ran `npm test` and all tests passed, including the new `src/telegramWebhook.test.js` checks. 
- Ran `npm run lint` and `node --check src/listingCreation.js src/telegramWebhook.js api/telegram/webhook.js` with no errors. 
- End-to-end behavior validated locally via unit tests that simulate Supabase and Telegram API calls and assert per-listing success/failure reporting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab1d5360748326a290358f2c3c6aea)