### PR TITLE
Increase Telegram webhook batch listing limit to 25

### DIFF
--- a/src/telegramWebhook.js
+++ b/src/telegramWebhook.js
@@ -7,6 +7,8 @@ import {
   validateDealForCreate,
 } from './listingCreation.js';
 
+const MAX_LISTINGS_PER_BATCH = 25;
+
 function splitListingBlocks(raw = '') {
   return String(raw)
     .split(/\n\s*===+\s*\n/g)
@@ -145,6 +147,25 @@ export function createTelegramWebhookHandler({
       return;
     }
 
+    if (blocks.length > MAX_LISTINGS_PER_BATCH) {
+      const replyResult = await sendTelegramMessage({
+        fetchImpl,
+        botToken,
+        chatId,
+        text: `❌ Maximum ${MAX_LISTINGS_PER_BATCH} listings per message. You sent ${blocks.length} listings.`,
+      });
+      console.log('[telegram webhook] Telegram reply result', replyResult);
+      res.status(200).json({
+        ok: true,
+        processed: 0,
+        created: 0,
+        failed: 0,
+        ignored: true,
+        reason: 'max_listings_exceeded',
+      });
+      return;
+    }
+
     const supabase = createSupabaseClient(supabaseUrl, serviceRoleKey);
 
     const results = [];
@@ -224,5 +245,6 @@ export function createTelegramWebhookHandler({
 }
 
 export const _internal = {
+  MAX_LISTINGS_PER_BATCH,
   splitListingBlocks,
 };

--- a/src/telegramWebhook.test.js
+++ b/src/telegramWebhook.test.js
@@ -83,3 +83,60 @@ test('telegram handler processes multiple listings and reports failures', async 
   assert.equal(fetchCalls.length, 1);
   assert.match(fetchCalls[0].options.body, /Batch processed: 3/);
 });
+
+
+test('telegram handler rejects batches over max listing limit', async () => {
+  process.env.TELEGRAM_BOT_TOKEN = 'token';
+  process.env.TELEGRAM_WEBHOOK_SECRET = 'secret';
+  process.env.SUPABASE_URL = 'https://supabase.example';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+
+  const inserts = [];
+  const fetchCalls = [];
+
+  const handler = createTelegramWebhookHandler({
+    fetchImpl: async (url, options) => {
+      fetchCalls.push({ url, options });
+      return { ok: true, json: async () => ({ ok: true }) };
+    },
+    createSupabaseClient: () => ({
+      from() {
+        return {
+          insert(payload) {
+            inserts.push(payload[0]);
+            return { error: null };
+          },
+        };
+      },
+    }),
+  });
+
+  const listings = Array.from({ length: _internal.MAX_LISTINGS_PER_BATCH + 1 }, (_, index) => [
+    `Title: Listing ${index + 1}`,
+    'Deal Type: SALE',
+    `Product URL: https://example.com/${index + 1}`,
+  ].join('\n')).join('\n===\n');
+
+  const req = {
+    method: 'POST',
+    headers: { 'x-telegram-bot-api-secret-token': 'secret' },
+    body: {
+      message: {
+        chat: { id: 12345 },
+        text: listings,
+      },
+    },
+    query: {},
+  };
+
+  const res = makeRes();
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.body.processed, 0);
+  assert.equal(res.body.created, 0);
+  assert.equal(res.body.failed, 0);
+  assert.equal(inserts.length, 0);
+  assert.equal(fetchCalls.length, 1);
+  assert.match(fetchCalls[0].options.body, /Maximum 25 listings per message\. You sent 26 listings\./);
+});

--- a/src/telegramWebhook.test.js
+++ b/src/telegramWebhook.test.js
@@ -138,5 +138,9 @@ test('telegram handler rejects batches over max listing limit', async () => {
   assert.equal(res.body.failed, 0);
   assert.equal(inserts.length, 0);
   assert.equal(fetchCalls.length, 1);
-  assert.match(fetchCalls[0].options.body, /Maximum 25 listings per message\. You sent 26 listings\./);
+  const maxListings = _internal.MAX_LISTINGS_PER_BATCH;
+  const expectedMessageRegex = new RegExp(
+    `Maximum ${maxListings} listings per message\\. You sent ${maxListings + 1} listings\\.`
+  );
+  assert.match(fetchCalls[0].options.body, expectedMessageRegex);
 });


### PR DESCRIPTION
### Motivation
- Allow a single Telegram message to include up to 25 listings instead of the previous small limit. 
- Prevent large batches from being partially processed and overwhelming the webhook or DB. 
- Keep the existing parsing format, validation flow, Supabase inserts, and reporting unchanged for valid batches.

### Description
- Added `const MAX_LISTINGS_PER_BATCH = 25;` near the top of `src/telegramWebhook.js` and exported it via `_internal` for testability. 
- Added a check that if `blocks.length > MAX_LISTINGS_PER_BATCH` the handler does not process any listings and replies with: `❌ Maximum 25 listings per message. You sent X listings.` 
- Left structured listing parsing (separator `===`), validation, Supabase inserts, and success/failure reporting unchanged for batches with `<= 25` listings. 
- Added a test `telegram handler rejects batches over max listing limit` in `src/telegramWebhook.test.js` that verifies over-limit batches are rejected, no inserts occur, and the Telegram error message is sent.

### Testing
- Ran `node --test src/telegramWebhook.test.js` and all tests passed (3/3). 
- The new test confirms a 26-listing payload triggers the exact error reply and prevents any DB inserts. 
- Existing tests for parsing and multi-listing processing continue to pass, validating unchanged behavior for valid batches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ac897e593c83268fb921adb9db1672)