### PR TITLE
Make deals listings display in responsive 3/2/1 grid

### DIFF
--- a/styles.js
+++ b/styles.js
@@ -42,6 +42,35 @@ input:focus,select:focus,textarea:focus{border-color:var(--p)}
 .nav-logo{font-size:20px;font-weight:700;color:var(--p);flex:1}
 .page{max-width:1100px;margin:0 auto;padding:24px 16px}
 .grid2{display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:18px}
+.listings-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 20px;
+  align-items: stretch;
+}
+
+.listings-grid > * {
+  min-width: 0;
+}
+
+.listings-grid img {
+  width: 100%;
+  height: auto;
+  display: block;
+  object-fit: cover;
+}
+
+@media (max-width: 900px) {
+  .listings-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 600px) {
+  .listings-grid {
+    grid-template-columns: 1fr;
+  }
+}
 .deal-card{background:var(--surf);border:1.5px solid var(--bdr);border-radius:var(--rad);overflow:hidden;transition:all .2s;cursor:pointer}
 .deal-card:hover{border-color:var(--p);box-shadow:var(--sh);transform:translateY(-2px)}
 .deal-img{width:100%;height:160px;background:var(--surf2);overflow:hidden;position:relative}
@@ -1098,7 +1127,7 @@ function DealsPage(){
               <p style={{marginTop:12}}>No deals found. Try adjusting your filters.</p>
             </div>
           ):(
-            <div className="grid2">
+            <div className="grid2 listings-grid">
               {deals.map(d=><DealCard key={d.id} deal={d}/>)}
             </div>
           )}


### PR DESCRIPTION
### Motivation
- Convert the deals/listings area from the existing single-column/auto-fill layout to a controlled 3/2/1 responsive grid so multiple listing cards appear per row on wider screens while preserving existing styles and behavior. 

### Description
- Added the exact provided `.listings-grid` CSS block into `styles.js` to implement a CSS Grid layout with `3` columns on desktop, `2` on tablet, and `1` on mobile, plus spacing and image scaling rules. 
- Applied the wrapper `listings-grid` class to the main deals container by changing the container from `className="grid2"` to `className="grid2 listings-grid"` so existing `.grid2` rules and card markup remain intact. 
- Kept all existing listing card classes, fonts, colors, buttons, header/footer, and other site functionality unchanged. 

### Testing
- Ran `npm run build` which completed successfully and produced the production bundle. 
- Started the dev server with `npm run dev` to validate runtime rendering of the page. 
- Captured a visual snapshot using an automated Playwright script to confirm the page loads and the listings container renders with the new grid wrapper.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ac91638cc88326ae13c85b87b3137d)