### PR TITLE
Fix deal expiration logic when no expiration date is set

### DIFF
--- a/styles.js
+++ b/styles.js
@@ -102,10 +102,18 @@ const now = new Date(); // used only for ad() and sd() seed data helpers
 const ad = (days) => { const d=new Date(now); d.setDate(d.getDate()+days); return d.toISOString(); };
 const sd = (days) => { const d=new Date(now); d.setDate(d.getDate()-days); return d.toISOString(); };
 
+const isDealExpired = (expireDate) => {
+  if (!expireDate) return false;
+  const expiration = new Date(expireDate);
+  if (Number.isNaN(expiration.getTime())) return false;
+  return new Date() > expiration;
+};
+
 // Bug 2 fixed: tu() now computes current time fresh on every call
 const tu = (d)=>{
+  if (!d) return "No expiration";
+  if (isDealExpired(d)) return "Expired";
   const diff = new Date(d) - new Date(); // always current time
-  if(diff<0) return "Expired";
   const days=Math.floor(diff/864e5), hrs=Math.floor((diff%864e5)/36e5);
   return days>0?`${days}d ${hrs}h left`:`${hrs}h left`;
 };
@@ -121,7 +129,12 @@ const timeSince = (d) => {
   return `Added ${days} day${days===1?"":"s"} ago`;
 };
 
-const fmtDate = (s) => new Date(s).toLocaleDateString("en-US",{month:"short",day:"numeric",year:"numeric"});
+const fmtDate = (s) => {
+  if (!s) return "No expiration";
+  const parsed = new Date(s);
+  if (Number.isNaN(parsed.getTime())) return "No expiration";
+  return parsed.toLocaleDateString("en-US",{month:"short",day:"numeric",year:"numeric"});
+};
 export const PRIZE_AMOUNT_USD = 10;
 
 // ── Seed data ────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Deals without an `expires` value were being shown as expired due to comparing against an invalid/empty date.  
- The intended behavior is to only mark a deal expired if a valid expiration date exists and that date is in the past.  
- This change enforces the rule that missing or invalid `expires` values do not imply expiration.

### Description
- Added `isDealExpired(expireDate)` helper in `styles.js` that returns `false` when `expireDate` is missing/empty or invalid and only returns `true` when a valid date is in the past.  
- Updated the countdown helper `tu()` to first check for a present/valid expiration and only show `Expired` when `isDealExpired(...)` is `true`.  
- Updated `fmtDate()` to return `"No expiration"` for missing/invalid values to avoid showing epoch/invalid dates.  
- All other functionality is preserved and only the expiration decision/display behavior was changed.

### Testing
- Ran unit tests with `npm test` and all tests passed (`58` assertions passed, `0` failed).  
- Built the production bundle with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ac9202da988326bba399f17828113a)