### PR TITLE
Add Vercel Speed Insights instrumentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@vercel/analytics": "^1.5.0",
     "@supabase/supabase-js": "^2.97.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "@vercel/speed-insights": "^1.1.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",

--- a/styles.js
+++ b/styles.js
@@ -2948,6 +2948,26 @@ function VercelAnalytics(){
   return AnalyticsComponent ? <AnalyticsComponent /> : null;
 }
 
+function VercelSpeedInsights(){
+  const [SpeedInsightsComponent, setSpeedInsightsComponent] = useState(null);
+
+  useEffect(()=>{
+    let active = true;
+
+    import('@vercel/speed-insights/react')
+      .then(({ SpeedInsights })=>{
+        if (active && SpeedInsights) {
+          setSpeedInsightsComponent(() => SpeedInsights);
+        }
+      })
+      .catch(()=>{});
+
+    return ()=>{ active = false; };
+  },[]);
+
+  return SpeedInsightsComponent ? <SpeedInsightsComponent /> : null;
+}
+
 // ── Mount ─────────────────────────────────────────────────────
 const root=ReactDOM.createRoot(document.getElementById("root"));
 root.render(
@@ -2957,6 +2977,7 @@ root.render(
         <AgeProvider>
           <App/>
           <VercelAnalytics/>
+          <VercelSpeedInsights/>
         </AgeProvider>
       </AuthProvider>
     </ToastProvider>


### PR DESCRIPTION
### Motivation
- Add Vercel Speed Insights so the app can collect frontend performance metrics site-wide.
- The project is a Vite React app (not Next.js), so the equivalent integration point is the app root render path instead of `app/layout.tsx`.

### Description
- Add `@vercel/speed-insights` to `dependencies` in `package.json` so the package is tracked by the project.
- Implement a new `VercelSpeedInsights` component in `styles.js` that lazily imports `@vercel/speed-insights/react` and exposes the `SpeedInsights` component when available.
- Mount `<VercelSpeedInsights />` alongside the existing analytics component at the app root render so it runs globally across pages.

### Testing
- Attempted `npm i @vercel/speed-insights`, but the install failed in this environment with a `403 Forbidden` from the npm registry, so the dependency was added directly to `package.json` (install should succeed in an environment with registry access). 
- Ran `npm run lint` which completed successfully (no lint errors reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ae37d2cd208326afd8b0e2c663185d)